### PR TITLE
Change name BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE to BTREE…

### DIFF
--- a/btree-lib/btree/include/btree_definition.h
+++ b/btree-lib/btree/include/btree_definition.h
@@ -110,9 +110,9 @@ typedef enum {
   BTREE_DEFINITION_NODE_RETRY_UNTIL_SUCCESS, /**< Type of decorator type retry
                                                 until success. */
   BTREE_DEFINITION_NODE_REPEAT, /**< Type of decorator type repeat. */
-  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE, /**< Type of decorator type
+  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS, /**< Type of decorator type
                                                        keep running until
-                                                       failure. */
+                                                       success. */
   BTREE_DEFINITION_NODE_INVERTER,      /**< Type of decorator type inverter. */
   BTREE_DEFINITION_NODE_FORCE_SUCCESS, /**< Type of decorator type force
                                           success. */
@@ -285,7 +285,7 @@ typedef struct btree_definition_config_functions {
 #define BTREE_DEFINITION_CREATE_NODE_KEEP_RUNNING_UNTIL_FAILURE(               \
     _success_target, _fail_target, _node_limit)                                \
   {                                                                            \
-    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE,             \
+    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS,             \
     .st_index = _success_target, .ft_index = _fail_target,                     \
     .decorator_node.node_limit = _node_limit,                                  \
   }

--- a/btree-lib/btree/src/btree_process.c
+++ b/btree-lib/btree/src/btree_process.c
@@ -175,7 +175,7 @@ btree_process_node(btree_definition_tree_data_t *struct_tree,
     break;
   }
 
-  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE:
+  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS:
   case BTREE_DEFINITION_NODE_REACTIVE_KEEP_RUNNING_UNTIL_FAILURE: {
     if ((struct_tree->last_node_state == BTREE_DEFINITION_STATUS_RUNNING) ||
         (struct_tree->last_node_state == BTREE_DEFINITION_STATUS_FAIL)) {

--- a/examples/ble-wifi/main/bt/include/btree_definition.h
+++ b/examples/ble-wifi/main/bt/include/btree_definition.h
@@ -110,9 +110,9 @@ typedef enum {
   BTREE_DEFINITION_NODE_RETRY_UNTIL_SUCCESS, /**< Type of decorator type retry
                                                 until success. */
   BTREE_DEFINITION_NODE_REPEAT, /**< Type of decorator type repeat. */
-  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE, /**< Type of decorator type
+  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS, /**< Type of decorator type
                                                        keep running until
-                                                       failure. */
+                                                       success. */
   BTREE_DEFINITION_NODE_INVERTER,      /**< Type of decorator type inverter. */
   BTREE_DEFINITION_NODE_FORCE_SUCCESS, /**< Type of decorator type force
                                           success. */
@@ -278,7 +278,7 @@ typedef struct btree_definition_config_functions {
 #define BTREE_DEFINITION_CREATE_NODE_KEEP_RUNNING_UNTIL_FAILURE(               \
     _success_target, _fail_target, _node_limit)                       \
   {                                                                            \
-    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE,             \
+    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS,             \
     .st_index = _success_target, .ft_index = _fail_target,                     \
     .decorator_node.node_limit = _node_limit,                        \
   }

--- a/examples/ble-wifi/main/bt/src/btree_process.c
+++ b/examples/ble-wifi/main/bt/src/btree_process.c
@@ -173,7 +173,7 @@ btree_process_node(btree_definition_tree_data_t *struct_tree,
     break;
   }
 
-  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE:
+  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS:
   case BTREE_DEFINITION_NODE_REACTIVE_KEEP_RUNNING_UNTIL_FAILURE: {
     
     if ((struct_tree->last_node_state == BTREE_DEFINITION_STATUS_RUNNING) ||

--- a/examples/btree-example-subtree/bt/include/btree_definition.h
+++ b/examples/btree-example-subtree/bt/include/btree_definition.h
@@ -110,9 +110,9 @@ typedef enum {
   BTREE_DEFINITION_NODE_RETRY_UNTIL_SUCCESS, /**< Type of decorator type retry
                                                 until success. */
   BTREE_DEFINITION_NODE_REPEAT, /**< Type of decorator type repeat. */
-  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE, /**< Type of decorator type
+  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS, /**< Type of decorator type
                                                        keep running until
-                                                       failure. */
+                                                       success. */
   BTREE_DEFINITION_NODE_INVERTER,      /**< Type of decorator type inverter. */
   BTREE_DEFINITION_NODE_FORCE_SUCCESS, /**< Type of decorator type force
                                           success. */
@@ -278,7 +278,7 @@ typedef struct btree_definition_config_functions {
 #define BTREE_DEFINITION_CREATE_NODE_KEEP_RUNNING_UNTIL_FAILURE(               \
     _success_target, _fail_target, _node_limit)                       \
   {                                                                            \
-    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE,             \
+    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS,             \
     .st_index = _success_target, .ft_index = _fail_target,                     \
     .decorator_node.node_limit = _node_limit,                        \
   }

--- a/examples/btree-example-subtree/bt/src/btree_process.c
+++ b/examples/btree-example-subtree/bt/src/btree_process.c
@@ -173,7 +173,7 @@ btree_process_node(btree_definition_tree_data_t *struct_tree,
     break;
   }
 
-  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE:
+  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS:
   case BTREE_DEFINITION_NODE_REACTIVE_KEEP_RUNNING_UNTIL_FAILURE: {
 //    BTREE_PROCESS_CHECK_TARGET(struct_tree, index);
     if ((struct_tree->last_node_state == BTREE_DEFINITION_STATUS_RUNNING) ||

--- a/examples/btree-long-tree/btree/include/btree_definition.h
+++ b/examples/btree-long-tree/btree/include/btree_definition.h
@@ -110,9 +110,9 @@ typedef enum {
   BTREE_DEFINITION_NODE_RETRY_UNTIL_SUCCESS, /**< Type of decorator type retry
                                                 until success. */
   BTREE_DEFINITION_NODE_REPEAT, /**< Type of decorator type repeat. */
-  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE, /**< Type of decorator type
+  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS, /**< Type of decorator type
                                                        keep running until
-                                                       failure. */
+                                                       success. */
   BTREE_DEFINITION_NODE_INVERTER,      /**< Type of decorator type inverter. */
   BTREE_DEFINITION_NODE_FORCE_SUCCESS, /**< Type of decorator type force
                                           success. */
@@ -285,7 +285,7 @@ typedef struct btree_definition_config_functions {
 #define BTREE_DEFINITION_CREATE_NODE_KEEP_RUNNING_UNTIL_FAILURE(               \
     _success_target, _fail_target, _node_limit)                                \
   {                                                                            \
-    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE,             \
+    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS,             \
     .st_index = _success_target, .ft_index = _fail_target,                     \
     .decorator_node.node_limit = _node_limit,                                  \
   }

--- a/examples/btree-long-tree/btree/src/btree_process.c
+++ b/examples/btree-long-tree/btree/src/btree_process.c
@@ -177,7 +177,7 @@ btree_process_node(btree_definition_tree_data_t *struct_tree,
     break;
   }
 
-  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE:
+  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS:
   case BTREE_DEFINITION_NODE_REACTIVE_KEEP_RUNNING_UNTIL_FAILURE: {
     if ((struct_tree->last_node_state == BTREE_DEFINITION_STATUS_RUNNING) ||
         (struct_tree->last_node_state == BTREE_DEFINITION_STATUS_FAIL)) {

--- a/examples/btree-msgs/main/bt/include/btree_definition.h
+++ b/examples/btree-msgs/main/bt/include/btree_definition.h
@@ -110,9 +110,9 @@ typedef enum {
   BTREE_DEFINITION_NODE_RETRY_UNTIL_SUCCESS, /**< Type of decorator type retry
                                                 until success. */
   BTREE_DEFINITION_NODE_REPEAT, /**< Type of decorator type repeat. */
-  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE, /**< Type of decorator type
+  BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS, /**< Type of decorator type
                                                        keep running until
-                                                       failure. */
+                                                       success. */
   BTREE_DEFINITION_NODE_INVERTER,      /**< Type of decorator type inverter. */
   BTREE_DEFINITION_NODE_FORCE_SUCCESS, /**< Type of decorator type force
                                           success. */
@@ -278,7 +278,7 @@ typedef struct btree_definition_config_functions {
 #define BTREE_DEFINITION_CREATE_NODE_KEEP_RUNNING_UNTIL_FAILURE(               \
     _success_target, _fail_target, _node_limit)                       \
   {                                                                            \
-    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE,             \
+    .node_type = BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS,             \
     .st_index = _success_target, .ft_index = _fail_target,                     \
     .decorator_node.node_limit = _node_limit,                        \
   }

--- a/examples/btree-msgs/main/bt/src/btree_process.c
+++ b/examples/btree-msgs/main/bt/src/btree_process.c
@@ -173,7 +173,7 @@ btree_process_node(btree_definition_tree_data_t *struct_tree,
     break;
   }
 
-  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_FAILURE:
+  case BTREE_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS:
   case BTREE_DEFINITION_NODE_REACTIVE_KEEP_RUNNING_UNTIL_FAILURE: {
     
     if ((struct_tree->last_node_state == BTREE_DEFINITION_STATUS_RUNNING) ||


### PR DESCRIPTION
…_DEFINITION_NODE_KEEP_RUNNING_UNTIL_SUCCESS.